### PR TITLE
Add support for academic services

### DIFF
--- a/content/authors/Mingshuai-Chen/_index.md
+++ b/content/authors/Mingshuai-Chen/_index.md
@@ -90,6 +90,37 @@ social:
   - icon: linkedin
     icon_pack: fab
     link: https://www.linkedin.com/in/mingshuai-chen-481838aa/
+
+academic_services:
+  # TODO: ICFEM'25, Special Issue...
+  editor_committee_chair:
+    - service: Workshop Chair of [ICFEM 2025]()
+      time: Nov. 2025
+    - service: Guest Editor of Special Issue on Formal Methods and Applications of Journal of Software
+      time: Nov. 2024
+    - service: Co-Chair of Forum on Formal Methods and Applications at [ChinaSoft 2024](https://chinasoft.ccf.org.cn/)
+      time: Nov. 2024
+    - service: Co-Chair of Forum on Theor. Eng. Software under Uncertainty at [ChinaSoft 2024](https://chinasoft.ccf.org.cn/)
+      time: Nov. 2024
+  committee_member:
+    - service: Senior Member of the [China Computer Federation (CCF)](https://www.ccf.org.cn/en/)
+    - service: Executive Member of [CCF Technical Committee](https://www.ccf.org.cn/en/About_CCF/Technical_Committees/) on Formal Methods
+    - service: Member of [CCF Technical Committee](https://www.ccf.org.cn/en/About_CCF/Technical_Committees/) on Theoretical Computer Science
+    - service: Reviewer Panel of [Mathematical Reviews](https://www.ams.org/publications/math-reviews/math-reviews)
+    # TODO: OOPSLA'26, TACAS'26
+    - service: "Program/Review Committee Member of
+      [OOPSLA 2026](),
+      [TACAS 2026]()/[2025](https://etaps.org/2025/conferences/tacas/),
+      [ATVA 2025](https://conf.researchr.org/home/atva-2025),
+      [TASE 2025](https://cyprusconferences.org/tase2025/),
+      [FSEN 2025](https://conf.researchr.org/home/fsen-2025),
+      [SETTA 2024](https://setta2024.cs.cityu.edu.hk/),
+      [RTCSA 2024](https://rtcsa2024.github.io/)/[2021](https://rtcsa2021.github.io/),
+      [ICWS 2024 (SRG Workshop)](https://icws.conferences.computer.org/2024/srg-workshop/),
+      [SYNASC 2022 (Logic and Programming Track)](https://synasc.ro/2022/logic-and-programming/)"
+    - service: "Repeatability/Artifact Evaluation Committee Member of
+      [ADHS 2021](https://sites.uclouvain.be/adhs21/),
+      [VMCAI 2021](https://popl21.sigplan.org/home/VMCAI-2021)"
 ---
 
 I am a US-equivalent tenure-track Assistant Professor leading the [Formal Verification Group](/) at Zhejiang University. Prior to joining ZJU, I worked as a Postdoctoral Researcher at the Software Modeling and Verification Group headed by Prof. Joost-Pieter Katoen at RWTH Aachen University. In 2019, I received the Ph.D. degree in computer science from the Institute of Software, Chinese Academy of Sciences under the supervision of Prof. Naijun Zhan and co-supervision of Prof. Martin Fränzle.

--- a/content/authors/Mingshuai-Chen/_index.md
+++ b/content/authors/Mingshuai-Chen/_index.md
@@ -94,23 +94,23 @@ social:
 academic_services:
   # TODO: ICFEM'25, Special Issue...
   editor_committee_chair:
-    - service: Workshop Chair of [ICFEM 2025]()
+    - service: Workshop Chair of [ICFEM 2025](https://icfem2025.github.io/)
       time: Nov. 2025
-    - service: Guest Editor of Special Issue on Formal Methods and Applications of Journal of Software
+    - service: Guest Editor of [Special Issue on Formal Methods and Applications of Journal of Software](https://www.jos.org.cn/jos/news/view/20241211090050001)
       time: Nov. 2024
     - service: Co-Chair of Forum on Formal Methods and Applications at [ChinaSoft 2024](https://chinasoft.ccf.org.cn/)
       time: Nov. 2024
-    - service: Co-Chair of Forum on Theor. Eng. Software under Uncertainty at [ChinaSoft 2024](https://chinasoft.ccf.org.cn/)
+    - service: Co-Chair of Forum on Theory and Engineering of Software under Uncertainty at [ChinaSoft 2024](https://chinasoft.ccf.org.cn/)
       time: Nov. 2024
   committee_member:
     - service: Senior Member of the [China Computer Federation (CCF)](https://www.ccf.org.cn/en/)
-    - service: Executive Member of [CCF Technical Committee](https://www.ccf.org.cn/en/About_CCF/Technical_Committees/) on Formal Methods
-    - service: Member of [CCF Technical Committee](https://www.ccf.org.cn/en/About_CCF/Technical_Committees/) on Theoretical Computer Science
+    - service: Executive Member of CCF Technical Committee on Formal Methods
+    - service: Member of CCF Technical Committee on Theoretical Computer Science
     - service: Reviewer Panel of [Mathematical Reviews](https://www.ams.org/publications/math-reviews/math-reviews)
     # TODO: OOPSLA'26, TACAS'26
     - service: "Program/Review Committee Member of
-      [OOPSLA 2026](),
-      [TACAS 2026]()/[2025](https://etaps.org/2025/conferences/tacas/),
+      OOPSLA 2026,
+      [TACAS](https://tacas.info/) 2026/[2025](https://etaps.org/2025/conferences/tacas/),
       [ATVA 2025](https://conf.researchr.org/home/atva-2025),
       [TASE 2025](https://cyprusconferences.org/tase2025/),
       [FSEN 2025](https://conf.researchr.org/home/fsen-2025),

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -134,25 +134,35 @@
 {{ with $person.academic_services }}
 <div class="article-widget">
   <h3>Academic Services</h3>
-  <p>Welcome to submit your work to the following [[ TBD: conferences ]]!</p>  
+  <p>
+    <svg width="30px" height="30px" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M10 18C8.89543 18 8 18.8954 8 20V26C8 27.1046 8.89543 28 10 28H14V18H10ZM14 30H12V38C12 38.5523 12.4477 39 13 39C13.5523 39 14 38.5523 14 38V30ZM10 30C7.79086 30 6 28.2091 6 26V20C6 17.7909 7.79086 16 10 16H15C15.5523 16 16 16.4477 16 17V38C16 39.6569 14.6569 41 13 41C11.3431 41 10 39.6569 10 38V30Z" fill="#333333" />
+    <path fill-rule="evenodd" clip-rule="evenodd"
+      d="M30.4812 7.12339C30.8012 7.29903 31 7.63502 31 8V18C33.2091 18 35 19.7909 35 22V23C35 25.2091 33.2091 27 31 27V37C31 37.365 30.8012 37.701 30.4812 37.8766C30.1613 38.0522 29.771 38.0396 29.4631 37.8437L18.4631 30.8437C18.1747 30.6601 18 30.3419 18 30V15C18 14.6581 18.1747 14.3399 18.4631 14.1563L29.4631 7.15634C29.771 6.96039 30.1613 6.94776 30.4812 7.12339ZM31 25C32.1046 25 33 24.1046 33 23V22C33 20.8954 32.1046 20 31 20V25ZM20 15.5489V29.4511L29 35.1783V9.82167L20 15.5489Z"
+      fill="#333333" />
+    <path fill-rule="evenodd" clip-rule="evenodd"
+      d="M40.832 17.4453C41.1384 17.9048 41.0142 18.5257 40.5547 18.832L37.5547 20.832C37.0952 21.1384 36.4743 21.0142 36.1679 20.5547C35.8616 20.0952 35.9858 19.4743 36.4453 19.1679L39.4453 17.1679C39.9048 16.8616 40.5257 16.9858 40.832 17.4453ZM36 24C36 23.4477 36.4477 23 37 23H41C41.5523 23 42 23.4477 42 24C42 24.5523 41.5523 25 41 25H37C36.4477 25 36 24.5523 36 24ZM36.1679 27.4453C36.4743 26.9858 37.0952 26.8616 37.5547 27.1679L40.5547 29.1679C41.0142 29.4743 41.1384 30.0952 40.832 30.5547C40.5257 31.0142 39.9048 31.1384 39.4453 30.832L36.4453 28.832C35.9858 28.5257 35.8616 27.9048 36.1679 27.4453Z"
+      fill="#333333" />
+    </svg>
+    I serve on the following academic committees. Consider submit your work to one of the venues!</p>  
   {{ if (len .editor_committee_chair) }}
     <div class="hr-light"></div>
     <h4>Editor & Committee Chair</h4>
-    <ol>
+    <ul>
       {{ range .editor_committee_chair }}
       <li>{{ .service | markdownify }}</li>
       {{ end }}
-    </ol>
+    </ul>
   {{ end }}
 
   {{ if (len .committee_member) }}
     <div class="hr-light"></div>
     <h4>Committee Member</h4>
-    <ol>
+    <ul>
       {{ range .committee_member }}
       <li>{{ .service | markdownify }}</li>
       {{ end }}
-    </ol>
+    </ul>
   {{ end }}
 
 </div>

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -130,3 +130,30 @@
     </div>
   </div>
 </div>
+
+{{ with $person.academic_services }}
+<div class="article-widget">
+  <h3>Academic Services</h3>
+  <p>Welcome to submit your work to the following [[ TBD: conferences ]]!</p>  
+  {{ if (len .editor_committee_chair) }}
+    <div class="hr-light"></div>
+    <h4>Editor & Committee Chair</h4>
+    <ol>
+      {{ range .editor_committee_chair }}
+      <li>{{ .service | markdownify }}</li>
+      {{ end }}
+    </ol>
+  {{ end }}
+
+  {{ if (len .committee_member) }}
+    <div class="hr-light"></div>
+    <h4>Committee Member</h4>
+    <ol>
+      {{ range .committee_member }}
+      <li>{{ .service | markdownify }}</li>
+      {{ end }}
+    </ol>
+  {{ end }}
+
+</div>
+{{ end }}


### PR DESCRIPTION
This PR adds support for academic services. To enable this feature, add the following fields to the authors' pages:

```yaml
academic_services:
  editor_committee_chair:
    - service: "..."
    - service: "..."
  committee_member:
    - service: "..."
    - service: "..."
```